### PR TITLE
Feat/#21 User,Record 

### DIFF
--- a/floe/src/main/java/project/floe/domain/comment/controller/CommentController.java
+++ b/floe/src/main/java/project/floe/domain/comment/controller/CommentController.java
@@ -1,5 +1,6 @@
 package project.floe.domain.comment.controller;
 
+import jakarta.servlet.http.HttpServletRequest;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
@@ -30,11 +31,12 @@ import project.floe.global.result.ResultResponse;
 public class CommentController {
 
     private final CommentService commentService;
-    
+
     @PostMapping
-    public ResponseEntity<ResultResponse> createComment(@Valid @RequestBody CreateCommentRequest request) {
-        commentService.createComment(request); // 생성만 수행, 반환값 없음
-        return ResponseEntity.status(HttpStatus.CREATED) // 201 Created 상태 반환
+    public ResponseEntity<ResultResponse> createComment(@Valid @RequestBody CreateCommentRequest request,
+                                                        HttpServletRequest httpServletRequest) {
+        commentService.createComment(request, httpServletRequest);
+        return ResponseEntity.status(HttpStatus.CREATED)
                 .body(ResultResponse.of(ResultCode.COMMENT_CREATE_SUCCESS));
     }
 

--- a/floe/src/main/java/project/floe/domain/comment/dto/request/CreateCommentRequest.java
+++ b/floe/src/main/java/project/floe/domain/comment/dto/request/CreateCommentRequest.java
@@ -1,7 +1,7 @@
 package project.floe.domain.comment.dto.request;
 
-import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Size;
 import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
@@ -20,9 +20,9 @@ public class CreateCommentRequest {
     @NotNull(message = "사용자 ID는 필수입니다.")
     private Long userId;
 
-    @NotBlank(message = "댓글 내용은 필수입니다.")
+    @Size(min = 1, max = 200, message = "댓글 내용은 1자 이상 200자 이하로 작성해주세요.")
     private String content;
 
-    private Long parentId; // 부모 댓글 ID (답글인 경우 null 가능)
+    private Long parentId;
 
 }

--- a/floe/src/main/java/project/floe/domain/comment/dto/response/GetCommentResponse.java
+++ b/floe/src/main/java/project/floe/domain/comment/dto/response/GetCommentResponse.java
@@ -15,8 +15,7 @@ import project.floe.domain.comment.entity.Comment;
 public class GetCommentResponse {
 
     private Long commentId;
-    private Long recordId;
-    private Long userId;
+    private GetCommentUserResponse user;
     private String content;
     private Long parentId;
     private LocalDateTime createdAt;
@@ -24,10 +23,9 @@ public class GetCommentResponse {
     public static GetCommentResponse from(Comment comment) {
         return GetCommentResponse.builder()
                 .commentId(comment.getId())
-                .recordId(comment.getRecordId())
-                .userId(comment.getUserId())
+                .user(GetCommentUserResponse.from(comment.getUser()))
                 .content(comment.getContent())
-                .parentId(comment.getParent() != null ? comment.getParent().getId() : null)
+                .parentId(comment.getParent() == null ? null : comment.getParent().getId())
                 .createdAt(comment.getCreatedAt())
                 .build();
     }

--- a/floe/src/main/java/project/floe/domain/comment/dto/response/GetCommentUserResponse.java
+++ b/floe/src/main/java/project/floe/domain/comment/dto/response/GetCommentUserResponse.java
@@ -1,0 +1,27 @@
+package project.floe.domain.comment.dto.response;
+
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import project.floe.domain.user.entity.User;
+
+@Getter
+@Builder
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+@NoArgsConstructor
+public class GetCommentUserResponse {
+
+    private String nickname;
+    private String email;
+
+    public static GetCommentUserResponse from(User user) {
+        return GetCommentUserResponse.builder()
+                .nickname(user.getNickname())
+                .email(user.getEmail())
+                .build();
+    }
+
+
+}

--- a/floe/src/main/java/project/floe/domain/comment/entity/Comment.java
+++ b/floe/src/main/java/project/floe/domain/comment/entity/Comment.java
@@ -1,9 +1,22 @@
 package project.floe.domain.comment.entity;
 
-import jakarta.persistence.*;
-import lombok.*;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
 import org.hibernate.annotations.SQLDelete;
 import org.hibernate.annotations.Where;
+import project.floe.domain.record.entity.Record;
+import project.floe.domain.user.entity.User;
 import project.floe.entity.BaseEntity;
 
 @Entity
@@ -20,21 +33,13 @@ public class Comment extends BaseEntity {
     @Column(name = "comment_id")
     private Long id;
 
-    /*
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "record_id", nullable = false)
     private Record record;
-    */
-    @Column(name = "record_id", nullable = false)
-    private Long recordId;
 
-    /*
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "user_id", nullable = false)
     private User user;
-    */
-    @Column(name = "user_id", nullable = false)
-    private Long userId;
 
     @Column(nullable = false)
     private String content;
@@ -43,10 +48,10 @@ public class Comment extends BaseEntity {
     @JoinColumn(name = "parent_id")
     private Comment parent;
 
-    public static Comment create(Long recordId, Long userId, String content, Comment parent) {
+    public static Comment create(Record record, User user, String content, Comment parent) {
         return Comment.builder()
-                .recordId(recordId)
-                .userId(userId)
+                .record(record)
+                .user(user)
                 .content(content)
                 .parent(parent)
                 .build();

--- a/floe/src/main/java/project/floe/domain/comment/repository/CommentJpaRepository.java
+++ b/floe/src/main/java/project/floe/domain/comment/repository/CommentJpaRepository.java
@@ -11,6 +11,6 @@ import project.floe.domain.comment.entity.Comment;
 public interface CommentJpaRepository extends JpaRepository<Comment, Long> {
     Page<Comment> findByRecordId(Long recordId, Pageable pageable);
 
-    @Query("SELECT c FROM Comment c WHERE c.id = :parentId")
+    @Query("SELECT c FROM Comment c WHERE c.id = :parentId AND (c.isDeleted = false OR c.isDeleted = true)")
     Optional<Comment> findByIdIncludingDeleted(@Param("parentId") Long parentId);
 }

--- a/floe/src/main/java/project/floe/global/error/ErrorCode.java
+++ b/floe/src/main/java/project/floe/global/error/ErrorCode.java
@@ -24,32 +24,29 @@ public enum ErrorCode {
     COMMENT_NOT_FOUND_ERROR(404, "C004", "댓글을 찾을 수 없음"),
     COMMENT_DELETED_ERROR(404, "C005", "삭제된 댓글입니다"),
 
-    //Record
-    RECORD_NOT_FOUND_ERROR(400, "R001", "기록을 찾을 수 없음");
-
     // Media
     S3_UPLOAD_FAIL_ERROR(500, "M001", "파일을 S3에 업로드할 수 없음"),
     FILE_NAME_NOT_FOUND_ERROR(400, "M002", "파일 이름을 찾을 수 없음"),
     CANNOT_CONVERT_TO_BYTE(500, "M003", "파일을 바이트 배열로 변환할 수 없음"),
-    MEDIA_NOT_FOUND_ERROR(400,"M004", "미디어 파일을 찾을 수 없음"),
+    MEDIA_NOT_FOUND_ERROR(400, "M004", "미디어 파일을 찾을 수 없음"),
     UPDATE_FILE_SEQUENCE_MISMATCH(400, "M005", "업데이트된 파일 순서와, 넘겨준 파일의 위치가 맞지 않음"),
     // Record
     RECORD_NOT_FOUND_ERROR(404, "R001", "기록을 찾을 수 없음"),
-    RECORD_DELETED_OR_NOT_EXIST(404,"R002" ,"이미 삭제되거나 존재하지 않는 기록" ),
+    RECORD_DELETED_OR_NOT_EXIST(404, "R002", "이미 삭제되거나 존재하지 않는 기록"),
 
     //User
-    USER_NOT_FOUND_ERROR(404,"U001","유저를 찾을 수 없음"),
-    USER_ID_DUPLICATION_ERROR(400,"U002","중복된 아이디"),
-    USER_EMAIL_DUPLICATION_ERROR(400,"U003","중복된 이메일"),
-    USER_NICKNAME_DUPLICATION_ERROR(400, "U004", "중복된 닉네임" ),
+    USER_NOT_FOUND_ERROR(404, "U001", "유저를 찾을 수 없음"),
+    USER_ID_DUPLICATION_ERROR(400, "U002", "중복된 아이디"),
+    USER_EMAIL_DUPLICATION_ERROR(400, "U003", "중복된 이메일"),
+    USER_NICKNAME_DUPLICATION_ERROR(400, "U004", "중복된 닉네임"),
     EMAIL_NOT_FOUND_ERROR(400, "U005", "해당 이메일이 존재하지 않음"),
 
     //Auth
-    TOKEN_ACCESS_NOT_EXIST(401, "A001","토큰을 찾을 수 없음" ),
+    TOKEN_ACCESS_NOT_EXIST(401, "A001", "토큰을 찾을 수 없음"),
 
     // Record Like
-    RECORD_ALREADY_LIKED_ERROR(400,"RL01","이미 좋아요 한 기록"),
-    RECORD_LIKE_NOT_FOUNT_ERROR(404,"RL02","해당 기록에 좋아요를 하지 않음"),
+    RECORD_ALREADY_LIKED_ERROR(400, "RL01", "이미 좋아요 한 기록"),
+    RECORD_LIKE_NOT_FOUNT_ERROR(404, "RL02", "해당 기록에 좋아요를 하지 않음"),
     ;
 
     private final int status;

--- a/floe/src/main/java/project/floe/global/error/GlobalExceptionHandler.java
+++ b/floe/src/main/java/project/floe/global/error/GlobalExceptionHandler.java
@@ -15,7 +15,7 @@ import project.floe.global.error.exception.UserServiceException;
 @Slf4j
 @RestControllerAdvice
 public class GlobalExceptionHandler {
-    
+
     @ExceptionHandler(Exception.class)
     protected ResponseEntity<ErrorResponse> handleException(Exception e) {
         log.error(e.getMessage(), e);
@@ -48,7 +48,7 @@ public class GlobalExceptionHandler {
     }
 
     @ExceptionHandler(UserServiceException.class)
-    public ResponseEntity<ErrorResponse> handleUserServiceException(UserServiceException e){
+    public ResponseEntity<ErrorResponse> handleUserServiceException(UserServiceException e) {
         ErrorCode errorCode = e.getErrorCode();
         ErrorResponse response = ErrorResponse.of(errorCode);
         log.warn(errorCode.getMessage());
@@ -72,7 +72,6 @@ public class GlobalExceptionHandler {
 
         return ResponseEntity.status(errorCode.getStatus()).body(response);
     }
-}
 
     private ErrorResponse makeErrorResponse(ErrorCode errorCode) {
         return ErrorResponse.builder()
@@ -81,5 +80,8 @@ public class GlobalExceptionHandler {
                 .build();
     }
 }
+
+
+
 
 

--- a/floe/src/main/java/project/floe/global/error/GlobalExceptionHandler.java
+++ b/floe/src/main/java/project/floe/global/error/GlobalExceptionHandler.java
@@ -66,9 +66,9 @@ public class GlobalExceptionHandler {
     @ExceptionHandler(CommentException.class)
     public ResponseEntity<ErrorResponse> handleCommentException(CommentException e) {
         ErrorCode errorCode = e.getErrorCode();
-        ErrorResponse response = ErrorResponse.of(errorCode);
+        ErrorResponse response = makeErrorResponse(errorCode);
 
-        log.warn(errorCode.getMessage());
+        log.warn(e.getMessage());
 
         return ResponseEntity.status(errorCode.getStatus()).body(response);
     }

--- a/floe/src/main/java/project/floe/global/error/exception/CommentException.java
+++ b/floe/src/main/java/project/floe/global/error/exception/CommentException.java
@@ -8,12 +8,10 @@ import project.floe.global.error.ErrorCode;
 public class CommentException extends BusinessException {
 
     private final ErrorCode errorCode;
-    private final Long commentId;
 
     public CommentException(ErrorCode errorCode) {
         super(errorCode);
         this.errorCode = errorCode;
-        this.commentId = null;
     }
 
 }

--- a/floe/src/test/java/project/floe/domain/comment/service/CommentServiceTest.java
+++ b/floe/src/test/java/project/floe/domain/comment/service/CommentServiceTest.java
@@ -3,18 +3,20 @@ package project.floe.domain.comment.service;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.Mockito.any;
+import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
+import jakarta.servlet.http.HttpServletRequest;
 import java.util.List;
 import java.util.Optional;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
-import org.springframework.beans.factory.annotation.Autowired;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
 import org.springframework.boot.test.context.SpringBootTest;
-import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageImpl;
 import org.springframework.data.domain.PageRequest;
@@ -24,29 +26,54 @@ import project.floe.domain.comment.dto.request.UpdateCommentRequest;
 import project.floe.domain.comment.dto.response.GetCommentResponse;
 import project.floe.domain.comment.entity.Comment;
 import project.floe.domain.comment.repository.CommentJpaRepository;
+import project.floe.domain.record.entity.Record;
+import project.floe.domain.record.repository.RecordJpaRepository;
+import project.floe.domain.user.entity.User;
+import project.floe.domain.user.repository.UserRepository;
+import project.floe.global.auth.jwt.service.JwtService;
 import project.floe.global.error.ErrorCode;
 import project.floe.global.error.exception.CommentException;
 
 @SpringBootTest
 class CommentServiceTest {
 
-    @Autowired
+    @InjectMocks
     private CommentService commentService;
-    /*
-    @MockBean
-    private RecordRepository recordRepository;
 
-    @MockBean
+    @Mock
+    private RecordJpaRepository recordJpaRepository;
+
+    @Mock
     private UserRepository userRepository;
-    */
-    @MockBean
-    private CommentJpaRepository commentRepository;
+
+    @Mock
+    private CommentJpaRepository commentJpaRepository;
+
+    @Mock
+    private JwtService jwtService;
 
     private CreateCommentRequest createCommentRequest;
     private UpdateCommentRequest updateCommentRequest;
+    private Record record;
+    private User user;
+    private Comment parentComment;
+    private String email;
 
     @BeforeEach
     void setUp() {
+
+        email = "test@example.com";
+
+        record = Record.builder()
+                .id(1L)
+                .build();
+
+        user = User.builder()
+                .id(1L)
+                .nickname("testUser")
+                .email("test@example.com")
+                .build();
+
         createCommentRequest = CreateCommentRequest.builder()
                 .recordId(1L)
                 .userId(1L)
@@ -57,44 +84,58 @@ class CommentServiceTest {
         updateCommentRequest = UpdateCommentRequest.builder()
                 .content("수정된 댓글 내용")
                 .build();
+        parentComment = Comment.builder()
+                .id(1L)
+                .record(record)
+                .user(user)
+                .build();
     }
 
     @Test
     @DisplayName("부모 댓글이 없는 상태에서 댓글 생성 성공")
     void 댓글생성_부모댓글없음_성공() {
+
         Comment newComment = Comment.create(
-                createCommentRequest.getRecordId(),
-                createCommentRequest.getUserId(),
+                record,
+                user,
                 createCommentRequest.getContent(),
                 null
         );
 
-        when(commentRepository.save(any(Comment.class))).thenReturn(newComment);
+        when(jwtService.extractEmail(any(HttpServletRequest.class))).thenReturn(Optional.of(email));
+        when(recordJpaRepository.findById(record.getId())).thenReturn(Optional.of(record));
+        when(userRepository.findByEmail(email)).thenReturn(Optional.of(user));
+        when(commentJpaRepository.save(any(Comment.class))).thenReturn(newComment);
 
-        commentService.createComment(createCommentRequest);
+        commentService.createComment(createCommentRequest, mock(HttpServletRequest.class));
 
-        verify(commentRepository, times(1)).save(any(Comment.class));
+        verify(recordJpaRepository, times(1)).findById(record.getId());
+        verify(userRepository, times(1)).findByEmail(email);
+        verify(commentJpaRepository, times(1)).save(any(Comment.class));
+        verify(jwtService, times(1)).extractEmail(any(HttpServletRequest.class));
     }
 
     @Test
     @DisplayName("부모 댓글이 삭제된 상태에서 댓글 생성 시 예외 발생")
     void 댓글생성_부모댓글삭제됨_예외처리() {
-        Comment parentComment = Comment.builder()
-                .id(1L)
-                .build();
+
         parentComment.delete();
 
         createCommentRequest = CreateCommentRequest.builder()
-                .recordId(1L)
-                .userId(1L)
+                .recordId(record.getId())
+                .userId(user.getId())
                 .content("테스트 댓글")
-                .parentId(1L)
+                .parentId(parentComment.getId())
                 .build();
 
-        when(commentRepository.findByIdIncludingDeleted(1L)).thenReturn(Optional.of(parentComment));
+        when(jwtService.extractEmail(any(HttpServletRequest.class))).thenReturn(Optional.of(email));
+        when(recordJpaRepository.findById(record.getId())).thenReturn(Optional.of(record));
+        when(userRepository.findByEmail(email)).thenReturn(Optional.of(user));
+        when(commentJpaRepository.findByIdIncludingDeleted(parentComment.getId())).thenReturn(
+                Optional.of(parentComment));
 
         CommentException exception = assertThrows(CommentException.class,
-                () -> commentService.createComment(createCommentRequest));
+                () -> commentService.createComment(createCommentRequest, mock(HttpServletRequest.class)));
 
         assertThat(exception.getErrorCode()).isEqualTo(ErrorCode.COMMENT_CANNOT_REPLY_TO_DELETED);
     }
@@ -109,10 +150,13 @@ class CommentServiceTest {
                 .parentId(999L)
                 .build();
 
-        when(commentRepository.findByIdIncludingDeleted(999L)).thenReturn(Optional.empty());
+        when(jwtService.extractEmail(any(HttpServletRequest.class))).thenReturn(Optional.of(email));
+        when(recordJpaRepository.findById(record.getId())).thenReturn(Optional.of(record));
+        when(userRepository.findByEmail(email)).thenReturn(Optional.of(user));
+        when(commentJpaRepository.findByIdIncludingDeleted(999L)).thenReturn(Optional.empty());
 
         CommentException exception = assertThrows(CommentException.class,
-                () -> commentService.createComment(createCommentRequest));
+                () -> commentService.createComment(createCommentRequest, mock(HttpServletRequest.class)));
 
         assertThat(exception.getErrorCode()).isEqualTo(ErrorCode.COMMENT_PARENT_NOT_FOUND_ERROR);
     }
@@ -126,7 +170,7 @@ class CommentServiceTest {
                 .build();
         deletedComment.delete();
 
-        when(commentRepository.findById(1L)).thenReturn(Optional.of(deletedComment));
+        when(commentJpaRepository.findById(1L)).thenReturn(Optional.of(deletedComment));
 
         CommentException exception = assertThrows(CommentException.class,
                 () -> commentService.updateComment(1L, updateCommentRequest));
@@ -137,7 +181,7 @@ class CommentServiceTest {
     @Test
     @DisplayName("댓글 수정 시 존재하지 않는 댓글 예외 발생")
     void 댓글수정_존재하지않는댓글() {
-        when(commentRepository.findById(1L)).thenReturn(Optional.empty());
+        when(commentJpaRepository.findById(1L)).thenReturn(Optional.empty());
 
         CommentException exception = assertThrows(CommentException.class,
                 () -> commentService.updateComment(1L, updateCommentRequest));
@@ -148,7 +192,7 @@ class CommentServiceTest {
     @Test
     @DisplayName("댓글 삭제 시 존재하지 않는 댓글 예외 발생")
     void 댓글삭제_존재하지않는댓글() {
-        when(commentRepository.findById(1L)).thenReturn(Optional.empty());
+        when(commentJpaRepository.findById(1L)).thenReturn(Optional.empty());
 
         CommentException exception = assertThrows(CommentException.class,
                 () -> commentService.deleteComment(1L));
@@ -163,11 +207,11 @@ class CommentServiceTest {
                 .id(1L)
                 .build();
 
-        when(commentRepository.findById(1L)).thenReturn(Optional.of(comment));
+        when(commentJpaRepository.findById(1L)).thenReturn(Optional.of(comment));
 
         commentService.deleteComment(1L);
 
-        verify(commentRepository, times(1)).delete(comment);
+        verify(commentJpaRepository, times(1)).delete(comment);
     }
 
 
@@ -179,7 +223,7 @@ class CommentServiceTest {
                 .content("기존 내용")
                 .build();
 
-        when(commentRepository.findById(1L)).thenReturn(Optional.of(comment));
+        when(commentJpaRepository.findById(1L)).thenReturn(Optional.of(comment));
 
         commentService.updateComment(1L, updateCommentRequest);
 
@@ -188,56 +232,51 @@ class CommentServiceTest {
 
 
     @Test
-    @DisplayName("댓글 페이징 조회 성공")
+    @DisplayName("댓글 페이징 조회 성공 테스트")
     void 댓글페이징조회_성공() {
-        // Given: Mock 데이터 준비
         Comment comment1 = Comment.builder()
                 .id(1L)
-                .recordId(1L)
-                .userId(1L)
+                .record(record)
+                .user(user)
                 .content("댓글 내용 1")
                 .build();
 
         Comment comment2 = Comment.builder()
                 .id(2L)
-                .recordId(1L)
-                .userId(2L)
+                .record(record)
+                .user(user)
                 .content("댓글 내용 2")
                 .build();
 
-        List<Comment> commentList = List.of(comment1, comment2);
-        Page<Comment> mockPage = new PageImpl<>(commentList);
+        List<Comment> comments = List.of(comment1, comment2);
+        Page<Comment> commentPage = new PageImpl<>(comments);
 
-        Pageable pageable = PageRequest.of(0, 5); // 페이지 요청
+        Pageable pageable = PageRequest.of(0, 5);
 
-        when(commentRepository.findByRecordId(1L, pageable)).thenReturn(mockPage);
+        when(commentJpaRepository.findByRecordId(1L, pageable)).thenReturn(commentPage);
 
-        // When: 서비스 호출
-        Page<GetCommentResponse> result = commentService.getCommentsByRecordId(1L, pageable);
+        Page<GetCommentResponse> response = commentService.getCommentsByRecordId(1L, pageable);
 
-        // Then: 검증
-        assertThat(result).isNotNull();
-        assertThat(result.getTotalElements()).isEqualTo(2); // 총 댓글 수
-        assertThat(result.getContent()).hasSize(2); // 페이지 내 댓글 수
-        assertThat(result.getContent().get(0).getContent()).isEqualTo("댓글 내용 1");
-        assertThat(result.getContent().get(1).getContent()).isEqualTo("댓글 내용 2");
+        assertThat(response.getContent().size()).isEqualTo(2);
+        assertThat(response.getContent().get(0).getContent()).isEqualTo("댓글 내용 1");
+        assertThat(response.getContent().get(0).getUser().getNickname()).isEqualTo("testUser");
+        assertThat(response.getContent().get(1).getContent()).isEqualTo("댓글 내용 2");
+        assertThat(response.getContent().get(1).getUser().getEmail()).isEqualTo("test@example.com");
     }
 
     @Test
     @DisplayName("댓글 페이징 조회 - 빈 결과")
     void 댓글페이징조회_빈결과() {
-        // Given: Mock 데이터 준비
-        Page<Comment> mockPage = new PageImpl<>(List.of()); // 빈 페이지
-        Pageable pageable = PageRequest.of(0, 5); // 페이지 요청
 
-        when(commentRepository.findByRecordId(999L, pageable)).thenReturn(mockPage);
+        Page<Comment> mockPage = new PageImpl<>(List.of());
+        Pageable pageable = PageRequest.of(0, 5);
 
-        // When: 서비스 호출
+        when(commentJpaRepository.findByRecordId(999L, pageable)).thenReturn(mockPage);
+
         Page<GetCommentResponse> result = commentService.getCommentsByRecordId(999L, pageable);
 
-        // Then: 검증
         assertThat(result).isNotNull();
-        assertThat(result.getTotalElements()).isEqualTo(0); // 총 댓글 수가 0
-        assertThat(result.getContent()).isEmpty(); // 페이지 내 댓글 없음
+        assertThat(result.getTotalElements()).isEqualTo(0);
+        assertThat(result.getContent()).isEmpty();
     }
 }


### PR DESCRIPTION
- 댓글 엔티티 유저와 레코드 연동
- 이에 따른 댓글 서비스 연동
- jwt를 이용해 user 찾기
- 댓글 컨트롤러 HttpServletRequest 추가
- 유저id가 아닌 nickname과 email 넘기기
- 댓글 테스트 연동
- merge 실수한 부분 수정


close #21 