### PR TITLE
Feat/#20 제목 + 태그 + 레코드 타입을 이용한 검색

### DIFF
--- a/floe/src/main/java/project/floe/domain/comment/service/CommentService.java
+++ b/floe/src/main/java/project/floe/domain/comment/service/CommentService.java
@@ -55,8 +55,7 @@ public class CommentService {
         Comment comment = Comment.create(record, user, request.getContent(), parent);
         commentRepository.save(comment);
     }
-
-    @Transactional(readOnly = true)
+    
     public Page<GetCommentResponse> getCommentsByRecordId(Long recordId, Pageable pageable) {
         Page<Comment> comments = commentRepository.findByRecordId(recordId, pageable);
         return comments.map(GetCommentResponse::from);

--- a/floe/src/main/java/project/floe/domain/record/controller/RecordController.java
+++ b/floe/src/main/java/project/floe/domain/record/controller/RecordController.java
@@ -21,6 +21,7 @@ import org.springframework.web.bind.annotation.RequestPart;
 import org.springframework.web.bind.annotation.RestController;
 import org.springframework.web.multipart.MultipartFile;
 import project.floe.domain.record.dto.request.CreateRecordRequest;
+import project.floe.domain.record.dto.request.SearchRecordRequest;
 import project.floe.domain.record.dto.request.UpdateRecordRequest;
 import project.floe.domain.record.dto.response.CreateRecordResponse;
 import project.floe.domain.record.dto.response.GetDetailRecordResponse;
@@ -28,8 +29,6 @@ import project.floe.domain.record.dto.response.GetRecordResponse;
 import project.floe.domain.record.dto.response.UpdateRecordResponse;
 import project.floe.domain.record.entity.Record;
 import project.floe.domain.record.service.RecordService;
-import project.floe.global.error.ErrorCode;
-import project.floe.global.error.exception.EmptyResultException;
 import project.floe.global.result.ResultCode;
 import project.floe.global.result.ResultResponse;
 
@@ -53,7 +52,8 @@ public class RecordController {
     }
 
     @GetMapping
-    public ResponseEntity<ResultResponse> getRecords(@PageableDefault(page = 0, size = 5, sort = "updatedAt", direction = Direction.DESC) Pageable pageable) {
+    public ResponseEntity<ResultResponse> getRecords(
+            @PageableDefault(page = 0, size = 5, sort = "updatedAt", direction = Direction.DESC) Pageable pageable) {
         Page<GetRecordResponse> response = recordService.findRecords(pageable);
         return ResponseEntity.ok(ResultResponse.of(ResultCode.RECORD_PAGING_GET_SUCCESS, response));
     }
@@ -81,6 +81,14 @@ public class RecordController {
         recordService.deleteRecord(recordId);
         return ResponseEntity.status(HttpStatus.OK)
                 .body(ResultResponse.of(ResultCode.RECORD_DELETE_SUCCESS));
+    }
+
+    @GetMapping("/search")
+    public ResponseEntity<ResultResponse> searchRecord(
+            @PageableDefault(page = 0, size = 5, sort = "updatedAt", direction = Direction.DESC) Pageable pageable,
+            SearchRecordRequest dto) {
+        Page<GetRecordResponse> response = recordService.searchRecords(pageable, dto);
+        return ResponseEntity.ok(ResultResponse.of(ResultCode.RECORD_SEARCH_SUCCESS, response));
     }
 
 }

--- a/floe/src/main/java/project/floe/domain/record/dto/request/SearchRecordRequest.java
+++ b/floe/src/main/java/project/floe/domain/record/dto/request/SearchRecordRequest.java
@@ -1,0 +1,22 @@
+package project.floe.domain.record.dto.request;
+
+import java.util.List;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import project.floe.domain.record.entity.RecordType;
+
+@Getter
+@Builder
+@AllArgsConstructor
+@NoArgsConstructor
+public class SearchRecordRequest {
+
+    private String title;
+
+    private RecordType recordType;
+
+    private List<String> tagNames;
+
+}

--- a/floe/src/main/java/project/floe/domain/record/repository/RecordJpaRepository.java
+++ b/floe/src/main/java/project/floe/domain/record/repository/RecordJpaRepository.java
@@ -1,9 +1,17 @@
 package project.floe.domain.record.repository;
 
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 import project.floe.domain.record.entity.Record;
+import project.floe.domain.record.entity.RecordType;
 
 @Repository
 public interface RecordJpaRepository extends JpaRepository<Record, Long> {
+    /*
+     * 태그가 없을 때 검색 시에 제목과 레코드 타입을 이용하여 레코드를 찾는다.
+     *
+     * */
+    Page<Record> findByTitleContainingAndRecordType(String title, RecordType recordType, Pageable pageable);
 }

--- a/floe/src/main/java/project/floe/domain/record/repository/RecordTagJpaRepository.java
+++ b/floe/src/main/java/project/floe/domain/record/repository/RecordTagJpaRepository.java
@@ -1,0 +1,30 @@
+package project.floe.domain.record.repository;
+
+import java.util.List;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+import project.floe.domain.record.entity.Record;
+import project.floe.domain.record.entity.RecordTag;
+import project.floe.domain.record.entity.RecordType;
+
+public interface RecordTagJpaRepository extends JpaRepository<RecordTag, Long> {
+    /*
+     *  검색 시에 태그와 제목, 레코드 타입을 이용하여 레코드를 찾는다.
+     *  dto로 붙어 받은 tagNames와 같은 tag를 찾고 tag_id를 이용해 record_tag를 찾는다.
+     *  record_tag.record_id를 이용해 record를 찾고 record.title과 record.recordType을 이용해 검색한다.
+     */
+    @Query("SELECT r FROM Record r " +
+            "JOIN r.recordTags.value rt " +
+            "JOIN rt.tag t " +
+            "WHERE t.tagName IN :tagNames " +
+            "AND r.title LIKE CONCAT('%', :title, '%') " +
+            "AND r.recordType = :recordType")
+    Page<Record> findRecordsByTagsAndTitleAndRecordType(
+            @Param("tagNames") List<String> tagNames,
+            @Param("title") String title,
+            @Param("recordType") RecordType recordType,
+            Pageable pageable);
+}

--- a/floe/src/main/java/project/floe/global/error/ErrorCode.java
+++ b/floe/src/main/java/project/floe/global/error/ErrorCode.java
@@ -34,6 +34,9 @@ public enum ErrorCode {
     RECORD_NOT_FOUND_ERROR(404, "R001", "기록을 찾을 수 없음"),
     RECORD_DELETED_OR_NOT_EXIST(404, "R002", "이미 삭제되거나 존재하지 않는 기록"),
 
+    // Record Search
+    RECORD_SEARCH_EMPTY_ERROR(400, "RS003", "검색어가 비어있음"),
+
     //User
     USER_NOT_FOUND_ERROR(404, "U001", "유저를 찾을 수 없음"),
     USER_ID_DUPLICATION_ERROR(400, "U002", "중복된 아이디"),
@@ -48,7 +51,7 @@ public enum ErrorCode {
     RECORD_ALREADY_LIKED_ERROR(400, "RL01", "이미 좋아요 한 기록"),
     RECORD_LIKE_NOT_FOUNT_ERROR(404, "RL02", "해당 기록에 좋아요를 하지 않음"),
     ;
-
+    
     private final int status;
     private final String code;
     private final String message;

--- a/floe/src/main/java/project/floe/global/error/GlobalExceptionHandler.java
+++ b/floe/src/main/java/project/floe/global/error/GlobalExceptionHandler.java
@@ -8,6 +8,7 @@ import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
 import project.floe.global.error.exception.BusinessException;
 import project.floe.global.error.exception.CommentException;
+import project.floe.global.error.exception.EmptyKeywordException;
 import project.floe.global.error.exception.EmptyResultException;
 import project.floe.global.error.exception.S3Exception;
 import project.floe.global.error.exception.UserServiceException;
@@ -65,6 +66,16 @@ public class GlobalExceptionHandler {
 
     @ExceptionHandler(CommentException.class)
     public ResponseEntity<ErrorResponse> handleCommentException(CommentException e) {
+        ErrorCode errorCode = e.getErrorCode();
+        ErrorResponse response = makeErrorResponse(errorCode);
+
+        log.warn(e.getMessage());
+
+        return ResponseEntity.status(errorCode.getStatus()).body(response);
+    }
+
+    @ExceptionHandler(EmptyKeywordException.class)
+    public ResponseEntity<ErrorResponse> handleEmptyKeywordException(EmptyKeywordException e) {
         ErrorCode errorCode = e.getErrorCode();
         ErrorResponse response = makeErrorResponse(errorCode);
 

--- a/floe/src/main/java/project/floe/global/error/exception/EmptyKeywordException.java
+++ b/floe/src/main/java/project/floe/global/error/exception/EmptyKeywordException.java
@@ -1,0 +1,17 @@
+package project.floe.global.error.exception;
+
+import lombok.Getter;
+import project.floe.global.error.ErrorCode;
+
+@Getter
+public class EmptyKeywordException extends BusinessException {
+
+    private final ErrorCode errorCode;
+
+    public EmptyKeywordException(ErrorCode errorCode) {
+        super(errorCode);
+        this.errorCode = errorCode;
+    }
+
+}
+

--- a/floe/src/main/java/project/floe/global/result/ResultCode.java
+++ b/floe/src/main/java/project/floe/global/result/ResultCode.java
@@ -4,7 +4,9 @@ import lombok.AllArgsConstructor;
 import lombok.Getter;
 
 
-/** {행위}_{목적어}_{성공여부} message 는 동사 명사형으로 마무리 */
+/**
+ * {행위}_{목적어}_{성공여부} message 는 동사 명사형으로 마무리
+ */
 
 @Getter
 @AllArgsConstructor
@@ -22,6 +24,9 @@ public enum ResultCode {
     RECORD_PAGING_GET_SUCCESS("R004", "페이징된 전체 기록 조회 성공"),
     RECORD_MODIFY_SUCCESS("R005", "기록 수정 성공"),
 
+    // Record Search
+    RECORD_SEARCH_SUCCESS("R006", "페이징된 기록 검색 성공"),
+
     // User
     USER_CREATE_SUCCESS("U001", "유저 생성 성공"),
     USER_GET_SUCCESS("U002", "유저 조회 성공"),
@@ -32,11 +37,11 @@ public enum ResultCode {
     USER_PROFILE_IMAGE_UPDATE_SUCCESS("U007", "프로필 사진 업데이트 성공"),
 
     // Record Like
-    RECORD_LIKE_COUNT_GET_SUCCESS("RL01","기록 좋아요 개수 조회 성공"),
-    RECORD_LIKE_POST_SUCCESS("RL02","기록 좋아요 추가 성공"),
-    RECORD_LIKE_DELETE_SUCCESS("RL03","기록 좋아요 삭제 성공"),
-    RECORD_LIKE_LIST_GET_SUCCESS("RL04","기록 좋아요 유저 목록 조회 성공");
-
+    RECORD_LIKE_COUNT_GET_SUCCESS("RL01", "기록 좋아요 개수 조회 성공"),
+    RECORD_LIKE_POST_SUCCESS("RL02", "기록 좋아요 추가 성공"),
+    RECORD_LIKE_DELETE_SUCCESS("RL03", "기록 좋아요 삭제 성공"),
+    RECORD_LIKE_LIST_GET_SUCCESS("RL04", "기록 좋아요 유저 목록 조회 성공");
+    
     private final String code;
     private final String message;
 }


### PR DESCRIPTION
- SearchRecordRequest 을 이용해 제목,태그,레코드 타입을 받는 dto 생성
- 서비스 로직에서 찾는게 아닌 jpa 에서 @query를 이용한 메서드를 통해 게시글 찾기
- 테스트를 통해 제목 + 태그 검색, 태그만 검색, 제목만 검색, 태그 x + 제목 x 시 Exception 발생 검사